### PR TITLE
ref: Various fixes and changes

### DIFF
--- a/benches/service.rs
+++ b/benches/service.rs
@@ -35,7 +35,7 @@ fn fibonacci(bencher: Bencher, projects: u64) {
             );
             for _ in 0..num_ops {
                 if rng.gen() {
-                    service.record_budget_spend(
+                    service.record_spending(
                         "test",
                         rng.gen_range(0..projects),
                         rng.gen_range(0.0..allowed_budget),

--- a/proto/project_budget.proto
+++ b/proto/project_budget.proto
@@ -3,7 +3,7 @@ package project_budget;
 
 service ProjectBudgets {
     rpc ExceedsBudget (ExceedsBudgetRequest) returns (ExceedsBudgetReply);
-    rpc RecordBudgetSpend (RecordBudgetSpendRequest) returns (ExceedsBudgetReply);
+    rpc RecordSpending (RecordSpendingRequest) returns (ExceedsBudgetReply);
 }
 
 message ExceedsBudgetRequest {
@@ -11,10 +11,10 @@ message ExceedsBudgetRequest {
     uint64 project_id = 2;
 }
 
-message RecordBudgetSpendRequest {
+message RecordSpendingRequest {
     string config_name = 1;
     uint64 project_id = 2;
-    double spent_budget = 3;
+    double spent = 3;
 }
 
 message ExceedsBudgetReply {

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,10 +18,12 @@ pub struct BudgetingConfig {
     /// The size of the buckets that spent budget is sorted into.
     pub bucket_size: Duration,
 
-    /// The total allowed budget before a project is flagged as exceeding it.
+    /// The budget assigned to each project.
     pub allowed_budget: f64,
 
-    /// Number of buckets to keep track of
+    /// The number of time buckets to keep track of.
+    ///
+    /// This should be at least ⌈budgeting_window/buckt_size⌉.
     pub(crate) num_buckets: usize,
 
     /// The [`Timer`] used to select the proper bucket.
@@ -36,6 +38,7 @@ impl BudgetingConfig {
         bucket_size: Duration,
         allowed_budget: f64,
     ) -> Self {
+        // Note: this is only correct if bucket_size divides budgeting_window
         let num_buckets = (budgeting_window.as_micros() / bucket_size.as_micros()) as usize;
         let timer = Timer::new(Clock::new());
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,7 @@ pub struct BudgetingConfig {
     pub bucket_size: Duration,
 
     /// The budget assigned to each project.
-    pub allowed_budget: f64,
+    pub budget: f64,
 
     /// The number of time buckets to keep track of.
     ///
@@ -36,7 +36,7 @@ impl BudgetingConfig {
         backoff_duration: Duration,
         budgeting_window: Duration,
         bucket_size: Duration,
-        allowed_budget: f64,
+        budget: f64,
     ) -> Self {
         // Note: this is only correct if bucket_size divides budgeting_window
         let num_buckets = (budgeting_window.as_micros() / bucket_size.as_micros()) as usize;
@@ -47,7 +47,7 @@ impl BudgetingConfig {
             budgeting_window,
             bucket_size,
             num_buckets,
-            allowed_budget,
+            budget,
             timer,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,9 +84,9 @@ impl Service {
     }
 
     /// Records spent budget.
-    pub fn record_budget_spend(&self, config: &str, project_id: u64, spent_budget: f64) -> bool {
+    pub fn record_spending(&self, config: &str, project_id: u64, spent: f64) -> bool {
         if let Some(mut stats) = self.get_project_stats(config, project_id, true) {
-            stats.record_budget_spend(spent_budget)
+            stats.record_spending(spent)
         } else {
             false
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,7 @@ impl Service {
 
     /// Checks whether this project exceeds its budgets.
     ///
-    /// This will also update internal state when checking.
-    /// An project that is not (yet) known will always return `false`,
+    /// A project that is not (yet) known will always return `false`,
     /// meaning it does not exceed the budget.
     pub fn exceeds_budget(&self, config: &str, project_id: u64) -> bool {
         if let Some(mut stats) = self.get_project_stats(config, project_id, false) {
@@ -85,8 +84,6 @@ impl Service {
     }
 
     /// Records spent budget.
-    ///
-    /// This will also update internal state when checking.
     pub fn record_budget_spend(&self, config: &str, project_id: u64, spent_budget: f64) -> bool {
         if let Some(mut stats) = self.get_project_stats(config, project_id, true) {
             stats.record_budget_spend(spent_budget)

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use tonic::{transport::Server, Request, Response, Status};
 
 use proto::project_budgets_server::{ProjectBudgets, ProjectBudgetsServer};
-use proto::{ExceedsBudgetReply, ExceedsBudgetRequest, RecordBudgetSpendRequest};
+use proto::{ExceedsBudgetReply, ExceedsBudgetRequest, RecordSpendingRequest};
 
 mod proto {
     tonic::include_proto!("project_budget");
@@ -64,19 +64,17 @@ impl ProjectBudgets for GrpcService {
         Ok(Response::new(ExceedsBudgetReply { exceeds_budget }))
     }
 
-    async fn record_budget_spend(
+    async fn record_spending(
         &self,
-        request: Request<RecordBudgetSpendRequest>,
+        request: Request<RecordSpendingRequest>,
     ) -> Result<Response<ExceedsBudgetReply>, Status> {
-        let RecordBudgetSpendRequest {
+        let RecordSpendingRequest {
             config_name,
             project_id,
-            spent_budget,
+            spent,
         } = request.into_inner();
 
-        let exceeds_budget = self
-            .inner
-            .record_budget_spend(&config_name, project_id, spent_budget);
+        let exceeds_budget = self.inner.record_spending(&config_name, project_id, spent);
 
         Ok(Response::new(ExceedsBudgetReply { exceeds_budget }))
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -14,7 +14,7 @@ pub struct ProjectStats {
     /// Configuration that governs the budgeting and bucketing.
     config: Arc<BudgetingConfig>,
 
-    /// Whether this project exceeded its budget.
+    /// Whether this project exceeds its budget in the current window.
     exceeds_budget: bool,
 
     /// The deadline after which a projects state can change, to avoid rapid flip-flopping.
@@ -37,8 +37,6 @@ impl ProjectStats {
     }
 
     /// Checks whether this project exceeds its budgets.
-    ///
-    /// This will also update internal state when checking.
     pub fn exceeds_budget(&mut self) -> bool {
         self.update_aggregated_state(self.config.truncated_now())
     }
@@ -76,7 +74,7 @@ impl ProjectStats {
         self.budget_buckets.iter().all(|b| b.0 < earliest_time)
     }
 
-    /// Updates the internal state, calculating whether this project exceeds its budget.
+    /// Checks whether this project exceeds its allotted budget.
     ///
     /// On state update, this will register a "backoff" timer to avoid rapid flip-flopping.
     fn update_aggregated_state(&mut self, now: Instant) -> bool {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -27,7 +27,8 @@ pub struct ProjectStats {
 impl ProjectStats {
     /// Create a new per-project tracker based on the given [`BudgetingConfig`].
     pub fn new(config: Arc<BudgetingConfig>) -> Self {
-        let budget_buckets = VecDeque::with_capacity(config.num_buckets);
+        // One extra bucket may temporarily exist when spending is recorded.
+        let budget_buckets = VecDeque::with_capacity(config.num_buckets + 1);
         Self {
             config,
             exceeds_budget: false,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -159,6 +159,7 @@ mod tests {
         assert!(!stats.exceeds_budget());
 
         // after *another* backoff, these stats are stale
-        assert!(!stats.is_stale(clock.now()));
+        mock.increment(Duration::from_secs(10));
+        assert!(stats.is_stale(clock.now()));
     }
 }


### PR DESCRIPTION
This is split into a few parts. They are independent in principle, so feel free to reject what you don't like.
# Bugfixes and refactors
* `is_stale` did the opposite of what it claimed; it returned `true` if any bucket was within the current time window, or in other words, if the stats were _not_ stale.
* I believe the logic for adding a new bucket in `record_budget_spend` is better expressed as
    ```rust
        match self.budget_buckets.front_mut() {
            Some(latest) if latest.0 >= now => latest.1 += spent,
            _ => self.budget_buckets.push_front((now, spent)),
        }

        if self.budget_buckets.len() > self.config.num_buckets {
            self.budget_buckets.pop_back();
        }
    ```
    even if it means possibly temporarily exceeding the number of buckets by 1.
# Documentation and comments
I mostly removed some "This will also update internal state when checking." notes because I don't think they're that helpful.
# Renaming
I renamed some functions and fields in a way I find clearer. To wit:
* `allowed_budget` → `budget`
* `record_budget_spend` → `record_spending`
* `spent_budget` → `spent`
* `update_aggregated_state` → `check_budget`
* `lowest_time` → `earliest_time`

Of these, the `check_budget` change is the only one I feel really strongly about.