### PR TITLE
Treat the budget as a per-second budget

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ impl Default for Service {
 
 /// A background maintenance task that periodically updates the [`Clock`],
 /// and cleans up state [`ProjectStats`].
-fn service_maintenance(clock: Clock, project_budgets: ProjectBudgets) {
+fn service_maintenance(timer: Clock, project_budgets: ProjectBudgets) {
     // We scan the map, and clean up stale entries in two phases.
     // The [`DashMap`] docs specifically mention that certain operations can deadlock,
     // such as iterating and calling `remove_if` at the same time.
@@ -126,7 +126,7 @@ fn service_maintenance(clock: Clock, project_budgets: ProjectBudgets) {
 
     loop {
         std::thread::sleep(Duration::from_millis(500));
-        let now = clock.now();
+        let now = timer.now();
         quanta::set_recent(now);
 
         for entry in project_budgets.iter() {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -39,31 +39,35 @@ impl ProjectStats {
 
     /// Checks whether this project exceeds its budgets.
     pub fn exceeds_budget(&mut self) -> bool {
-        self.check_budget(self.config.truncated_now())
+        let now = self.config.now();
+        let truncated_now = self.config.truncated_now(now);
+        self.check_budget(now, truncated_now)
     }
 
     /// Records spent budget.
     ///
     /// This will also update internal state when checking.
     pub fn record_spending(&mut self, spent: f64) -> bool {
-        let now = self.config.truncated_now();
+        let now = self.config.now();
+        let truncated_now = self.config.truncated_now(now);
 
         match self.budget_buckets.front_mut() {
-            Some(latest) if latest.0 >= now => latest.1 += spent,
-            _ => self.budget_buckets.push_front((now, spent)),
+            Some(latest) if latest.0 >= truncated_now => latest.1 += spent,
+            _ => self.budget_buckets.push_front((truncated_now, spent)),
         }
 
         if self.budget_buckets.len() > self.config.num_buckets {
             self.budget_buckets.pop_back();
         }
 
-        self.check_budget(now)
+        self.check_budget(now, truncated_now)
     }
 
     /// Checks whether all of the buckets are outside the current `budgeting_window`.
     ///
     /// This means that these stats can be cleaned up.
     pub fn is_stale(&self, now: Instant) -> bool {
+        let truncated_now = self.config.truncated_now(now);
         if let Some(deadline) = self.backoff_deadline {
             // we are in backoff, so no cleanup should happen
             if deadline > now {
@@ -71,14 +75,14 @@ impl ProjectStats {
             }
         }
 
-        let lowest_time = now - self.config.budgeting_window;
-        self.budget_buckets.iter().all(|b| b.0 < lowest_time)
+        let earliest_time = truncated_now - self.config.budgeting_window;
+        self.budget_buckets.iter().all(|b| b.0 < earliest_time)
     }
 
     /// Checks whether this project exceeds its allotted budget.
     ///
     /// On state update, this will register a "backoff" timer to avoid rapid flip-flopping.
-    fn check_budget(&mut self, now: Instant) -> bool {
+    fn check_budget(&mut self, now: Instant, truncated_now: Instant) -> bool {
         if let Some(deadline) = self.backoff_deadline {
             if deadline > now {
                 return self.exceeds_budget;
@@ -86,14 +90,9 @@ impl ProjectStats {
             self.backoff_deadline = None;
         }
 
-        let earliest_time = now - self.config.budgeting_window;
-        let total_spent_budget: f64 = self
-            .budget_buckets
-            .iter()
-            .filter_map(|b| (b.0 >= earliest_time).then_some(b.1))
-            .sum();
+        let spent_budget = self.spent_budget(now, truncated_now);
 
-        let exceeds_budget = total_spent_budget > self.config.budget;
+        let exceeds_budget = spent_budget > self.config.budget;
 
         if self.exceeds_budget != exceeds_budget {
             self.exceeds_budget = exceeds_budget;
@@ -101,6 +100,25 @@ impl ProjectStats {
         }
 
         exceeds_budget
+    }
+
+    /// Returns the spent budget, averaged *per-second*.
+    fn spent_budget(&self, now: Instant, truncated_now: Instant) -> f64 {
+        let earliest_time = truncated_now - self.config.budgeting_window;
+        let total_spent_budget: f64 = self
+            .budget_buckets
+            .iter()
+            .filter_map(|b| (b.0 >= earliest_time).then_some(b.1))
+            .sum();
+
+        // The configured budget is meant as a per-second budget.
+        // To calculate that, we want to divide by the real passed time,
+        // to avoid any artifacts resulting from the bucketing as much as possible.
+        let adjustment = now - truncated_now;
+        let adjusted_time_window =
+            self.config.budgeting_window - self.config.bucket_size + adjustment;
+
+        total_spent_budget / adjusted_time_window.as_secs_f64()
     }
 }
 
@@ -118,14 +136,15 @@ mod tests {
     fn test_budgeting() {
         let (clock, mock) = Clock::mock();
         mock.increment(Duration::from_secs(100));
+        let timer = Timer::new(clock);
 
         let config = BudgetingConfig::new(
             Duration::from_secs(10),
             Duration::from_secs(5),
             Duration::from_secs(1),
-            100.,
+            20.,
         )
-        .with_timer(Timer::new(clock.clone()));
+        .with_timer(timer.clone());
 
         let mut stats = ProjectStats::new(Arc::new(config));
 
@@ -140,7 +159,7 @@ mod tests {
 
         mock.increment(Duration::from_millis(750));
 
-        let is_blocked = stats.record_spending(10.);
+        let is_blocked = stats.record_spending(20.);
         assert!(is_blocked);
 
         mock.increment(Duration::from_secs(6));
@@ -160,6 +179,43 @@ mod tests {
 
         // after *another* backoff, these stats are stale
         mock.increment(Duration::from_secs(10));
-        assert!(stats.is_stale(clock.now()));
+        assert!(stats.is_stale(timer.now()));
+    }
+
+    #[test]
+    fn test_adjusted_budget() {
+        let (clock, mock) = Clock::mock();
+        mock.increment(Duration::from_secs(100));
+        let timer = Timer::new(clock);
+
+        let config = BudgetingConfig::new(
+            Duration::from_secs(10),
+            Duration::from_secs(5),
+            Duration::from_secs(1),
+            200.,
+        )
+        .with_timer(timer.clone());
+
+        let mut stats = ProjectStats::new(Arc::new(config));
+
+        // we spend `10` every `100ms`
+        for _ in 0..(5 * 10) {
+            stats.record_spending(10.);
+            mock.increment(Duration::from_millis(100));
+        }
+
+        for _ in 0..(5 * 10) {
+            let now = timer.now();
+            let truncated_now = stats.config.truncated_now(now);
+            let spent_budget = stats.spent_budget(now, truncated_now);
+            // FIXME:
+            // Ideally this should round to 100 all the time,
+            // but there still seems to be an edgecase in here somewhere:
+            // This rounds to 100 for 9/10 cases, but ~125 in 1/10.
+            dbg!(spent_budget);
+
+            stats.record_spending(10.);
+            mock.increment(Duration::from_millis(100));
+        }
     }
 }


### PR DESCRIPTION
This will now try (and fail in some edge-case) to properly round the spent budget to a per-second basis.