### PR TITLE
Experimentally add capnp implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - uses: arduino/setup-protoc@v3
+      - run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get install -y capnproto libcapnp-dev
 
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-features --workspace --tests --examples -- -D clippy::all
@@ -38,6 +41,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - uses: arduino/setup-protoc@v3
+      - run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get install -y capnproto libcapnp-dev
 
       - run: cargo doc --workspace --all-features --document-private-items --no-deps
 
@@ -57,6 +63,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - uses: arduino/setup-protoc@v3
+      - run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get install -y capnproto libcapnp-dev
 
       - run: cargo test --workspace --all-features --all-targets
       - run: cargo test --workspace --all-features --doc
@@ -73,6 +82,9 @@ jobs:
       - uses: taiki-e/install-action@cargo-llvm-cov
 
       - uses: arduino/setup-protoc@v3
+      - run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get install -y capnproto libcapnp-dev
 
       - run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
+name = "capnp"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11832e6fb7a695c4a63cc42bd97bd2cda7165cd850caf5aff9a3d0e617720ed"
+dependencies = [
+ "embedded-io",
+]
+
+[[package]]
+name = "capnp-futures"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fac483cb34e3bc0be251dba7ce318f465143dd18f948c7bd7ad035f6fecfb1b"
+dependencies = [
+ "capnp",
+ "futures",
+]
+
+[[package]]
+name = "capnp-rpc"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171dba986cf6aaa4a2a86f1a2fb7372f456d3cb95f2cb27f4dc45ae9ea850a16"
+dependencies = [
+ "capnp",
+ "capnp-futures",
+ "futures",
+]
+
+[[package]]
+name = "capnpc"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ba30e0f08582d53c2f3710cf4bb65ff562614b1ba86906d7391adffe189ec"
+dependencies = [
+ "capnp",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +301,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,12 +341,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -309,6 +370,34 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -328,10 +417,16 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -631,13 +726,18 @@ dependencies = [
 name = "peanutbutter"
 version = "0.1.0"
 dependencies = [
+ "capnp",
+ "capnp-rpc",
+ "capnpc",
  "dashmap",
  "divan",
+ "futures",
  "indexmap 2.2.5",
  "prost",
  "quanta",
  "rand",
  "tokio",
+ "tokio-util",
  "tonic",
  "tonic-build",
 ]
@@ -1048,6 +1148,7 @@ checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,19 @@ edition = "2021"
 debug = 1
 
 [dependencies]
+capnp = "0.19.3"
+capnp-rpc = "0.19.0"
 dashmap = "5.5.3"
+futures = "0.3.30"
 indexmap = "2.2.5"
 prost = "0.12.3"
 quanta = "0.12.2"
 tokio = { version = "1.36.0", features = ["macros", "rt-multi-thread"] }
+tokio-util = { version = "0.7.10", features = ["compat"] }
 tonic = "0.11.0"
 
 [build-dependencies]
+capnpc = "0.19.0"
 tonic-build = "0.11.0"
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,8 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("proto/project_budget.proto")?;
+    capnpc::CompilerCommand::new()
+        .src_prefix("proto")
+        .file("proto/project_budget.capnp")
+        .run()?;
     Ok(())
 }

--- a/proto/project_budget.capnp
+++ b/proto/project_budget.capnp
@@ -1,0 +1,21 @@
+@0x894cf35c57496706;
+
+interface ProjectBudgets {
+    exceedsBudget @0 (request: ExceedsBudgetRequest) -> (reply: ExceedsBudgetReply);
+    recordSpending @1 (request: RecordSpendingRequest) -> (reply: ExceedsBudgetReply);
+}
+
+struct ExceedsBudgetRequest {
+    configName @0 :Text;
+    projectId @1 :UInt64;
+}
+
+struct RecordSpendingRequest {
+    configName @0 :Text;
+    projectId @1 :UInt64;
+    spent @2 :Float64;
+}
+
+struct ExceedsBudgetReply {
+    exceedsBudget @0 :Bool;
+}

--- a/src/capnp.rs
+++ b/src/capnp.rs
@@ -1,0 +1,81 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use ::capnp::capability::Promise;
+use capnp_rpc::{pry, rpc_twoparty_capnp, twoparty, RpcSystem};
+use futures::AsyncReadExt;
+
+use peanutbutter::Service;
+
+use crate::project_budget_capnp::project_budgets;
+use project_budgets::{
+    ExceedsBudgetParams, ExceedsBudgetResults, RecordSpendingParams, RecordSpendingResults,
+};
+
+pub async fn start_capnp(
+    addr: SocketAddr,
+    service: Arc<Service>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let service = CapnpService { inner: service };
+    let client: project_budgets::Client = capnp_rpc::new_client(service);
+
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    loop {
+        let (stream, _) = listener.accept().await?;
+        stream.set_nodelay(true)?;
+        let (reader, writer) = tokio_util::compat::TokioAsyncReadCompatExt::compat(stream).split();
+        let network = twoparty::VatNetwork::new(
+            reader,
+            writer,
+            rpc_twoparty_capnp::Side::Server,
+            Default::default(),
+        );
+
+        let rpc_system = RpcSystem::new(Box::new(network), Some(client.clone().client));
+        tokio::task::spawn_local(rpc_system);
+    }
+}
+
+#[derive(Debug)]
+struct CapnpService {
+    inner: Arc<Service>,
+}
+
+impl project_budgets::Server for CapnpService {
+    fn exceeds_budget(
+        &mut self,
+        params: ExceedsBudgetParams,
+        mut results: ExceedsBudgetResults,
+    ) -> Promise<(), ::capnp::Error> {
+        let request = pry!(pry!(params.get()).get_request());
+        let config_name = pry!(pry!(request.get_config_name()).to_str());
+        let project_id = request.get_project_id();
+
+        let exceeds_budget = self.inner.exceeds_budget(config_name, project_id);
+
+        results
+            .get()
+            .init_reply()
+            .set_exceeds_budget(exceeds_budget);
+        Promise::ok(())
+    }
+
+    fn record_spending(
+        &mut self,
+        params: RecordSpendingParams,
+        mut results: RecordSpendingResults,
+    ) -> Promise<(), ::capnp::Error> {
+        let request = pry!(pry!(params.get()).get_request());
+        let config_name = pry!(pry!(request.get_config_name()).to_str());
+        let project_id = request.get_project_id();
+        let spent = request.get_spent();
+
+        let exceeds_budget = self.inner.record_spending(config_name, project_id, spent);
+
+        results
+            .get()
+            .init_reply()
+            .set_exceeds_budget(exceeds_budget);
+        Promise::ok(())
+    }
+}

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -1,0 +1,64 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use tonic::{transport::Server, Request, Response, Status};
+
+use proto::project_budgets_server::{ProjectBudgets, ProjectBudgetsServer};
+use proto::{ExceedsBudgetReply, ExceedsBudgetRequest, RecordSpendingRequest};
+
+use peanutbutter::Service;
+
+mod proto {
+    tonic::include_proto!("project_budget");
+}
+
+pub async fn start_grpc(
+    addr: SocketAddr,
+    service: Arc<Service>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let service = GrpcService { inner: service };
+
+    Server::builder()
+        .add_service(ProjectBudgetsServer::new(service))
+        .serve(addr)
+        .await?;
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct GrpcService {
+    inner: Arc<Service>,
+}
+
+#[tonic::async_trait]
+impl ProjectBudgets for GrpcService {
+    async fn exceeds_budget(
+        &self,
+        request: Request<ExceedsBudgetRequest>,
+    ) -> Result<Response<ExceedsBudgetReply>, Status> {
+        let ExceedsBudgetRequest {
+            config_name,
+            project_id,
+        } = request.into_inner();
+
+        let exceeds_budget = self.inner.exceeds_budget(&config_name, project_id);
+
+        Ok(Response::new(ExceedsBudgetReply { exceeds_budget }))
+    }
+
+    async fn record_spending(
+        &self,
+        request: Request<RecordSpendingRequest>,
+    ) -> Result<Response<ExceedsBudgetReply>, Status> {
+        let RecordSpendingRequest {
+            config_name,
+            project_id,
+            spent,
+        } = request.into_inner();
+
+        let exceeds_budget = self.inner.record_spending(&config_name, project_id, spent);
+
+        Ok(Response::new(ExceedsBudgetReply { exceeds_budget }))
+    }
+}


### PR DESCRIPTION
In order to compare it directly with the grpc implementation, here is the implementation using capnproto.

TBH, the developer experience is equally as bad, or even worse. Similarly, one needs to have `protoc` installed (for good reasons). The generated code hardcodes some `crate` paths for reasons I don’t understand. Plus, capnp brings its own `Promise` abstraction which is just a worse `Future`, and requires pretty much everything to be wrapped in `pry!` macros. It is also weird that the response is written into an out-parameter. Its not obvious what happens to it when an error is being returned.