### PR TITLE
meta(readme): Correctly describe per-second budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ but the intended use case is processing time.
 
 There are 4 important configuration parameters (which are currently hard-coded):
 
-- `budget`: How much a project is allowed to spend in a fixed time window. Currently 5.0.
+- `budget`: How much a project is allowed to spend on average per second within a fixed time window. Currently 5.0.
 - `budgeting_window`: The time window to which the budget applies. Currently 2 minutes.
 - `bucket_size`: The size of the time buckets spending gets sorted into. Currently 10 seconds.
 - `backoff_duration`: When a project's state changes (from within its budget to exceeding its budget, or the reverse)
   it can't change again for this length of time. Currently 5 minutes.
 
-Taking the default values as an example, each project has a budget of 5.0 units over 2 minutes, with spending
-recorded in 10-second blocks. As soon as a project has spent more than 5.0 units total
+Taking the default values as an example, each project has a budget of 5.0 units per second over 2 minutes, with spending
+recorded in 10-second blocks. As soon as a project has spent more than 5.0 units per second on average
 in the last 2 minutes, it's marked as exceeding its budget and will stay that way for at
 least 5 minutes, even if doesn't spend any more. Conversely, once it returns to being within its
 budget, it can't be marked as exceeding it again for 5 minutes.


### PR DESCRIPTION
As of https://github.com/getsentry/peanutbutter/pull/4, the budget is _per second_, but that was not reflected in the readme.