### PR TITLE
feat: Add `symbolication-jvm` config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,28 +14,20 @@ fn default_service() -> Service {
     let budgeting_window = Duration::from_secs(2 * 60);
     let bucket_size = Duration::from_secs(10);
 
-    // TODO: we might want to have separate native/js budgets
-    let allowed_budget = 5.0;
-
     let mut service = Service::new();
 
     service.add_config(
         "symbolication-native",
-        BudgetingConfig::new(
-            backoff_duration,
-            budgeting_window,
-            bucket_size,
-            allowed_budget,
-        ),
+        BudgetingConfig::new(backoff_duration, budgeting_window, bucket_size, 5.0),
     );
     service.add_config(
         "symbolication-js",
-        BudgetingConfig::new(
-            backoff_duration,
-            budgeting_window,
-            bucket_size,
-            allowed_budget,
-        ),
+        BudgetingConfig::new(backoff_duration, budgeting_window, bucket_size, 5.0),
+    );
+
+    service.add_config(
+        "symbolication-jvm",
+        BudgetingConfig::new(backoff_duration, budgeting_window, bucket_size, 7.5),
     );
 
     service


### PR DESCRIPTION
This adds a configuration for JVM symbolication. It has a higher budget than `js` and `native` because proguard symbolication is more expensive, but we might have to adjust this later.